### PR TITLE
RoutingMenuItem executes navigation only for client side selection.

### DIFF
--- a/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/RoutingMenuItem.java
+++ b/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/RoutingMenuItem.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 
 /**
  * A menu item for navigation.
+ * Navigation happens only when selection was fired from a client side.
  */
 public class RoutingMenuItem extends MenuItem {
 
@@ -61,13 +62,18 @@ public class RoutingMenuItem extends MenuItem {
      * @param title
      *            the title to display
      * @param route
-     *            the route to navigate on click
+     *            the route to navigate on the tab click
      */
     public RoutingMenuItem(Component icon, String title, String route) {
         super(icon, title);
 
         setRoute(route);
-        setListener(event -> UI.getCurrent().navigate(this.route));
+        setListener(event -> {
+            if (!event.isFromClient()) {
+                return;
+            }
+            UI.getCurrent().navigate(this.route);
+        });
     }
 
     /**


### PR DESCRIPTION
This resolves the issue of auto selection of first when the Tabs is populated and when corresponding tab is selected for the first page load

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-app-layout-flow/18)
<!-- Reviewable:end -->
