### PR TITLE
API to replace menu slot content

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Add App Layout to your project:
 ```java
 public class AppLayoutView extends AbstractAppRouterLayout {
     @Override
-    protected void configure(AppLayout appLayout) {
+    protected void configure(AppLayout appLayout, AppLayoutMenu appLayoutMenu) {
         appLayout.setBranding(new Span("App Name").getElement());
-        appLayout.addMenuItem(new AppLayoutMenuItem("About Company", "about"));
+        appLayoutMenu.addMenuItem(new AppLayoutMenuItem("About Company", "about"));
     }
 }
 /* Annotate AboutPage with @ParentLayout(AppLayoutView.class) */

--- a/vaadin-app-layout-flow-vaadincom-demo/src/main/java/com/vaadin/flow/component/applayout/vaadincom/AppLayoutView.java
+++ b/vaadin-app-layout-flow-vaadincom-demo/src/main/java/com/vaadin/flow/component/applayout/vaadincom/AppLayoutView.java
@@ -2,6 +2,7 @@ package com.vaadin.flow.component.applayout.vaadincom;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.applayout.AppLayout;
+import com.vaadin.flow.component.applayout.AppLayoutMenu;
 import com.vaadin.flow.component.applayout.AppLayoutMenuItem;
 import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.html.Image;
@@ -38,11 +39,12 @@ public class AppLayoutView extends DemoView {
         // begin-source-example
         // source-example-heading: Simple App Layout with brand logo
         AppLayout appLayout = new AppLayout();
+        AppLayoutMenu menu = appLayout.createMenu();
         Image img = new Image("https://i.imgur.com/GPpnszs.png", "Vaadin Logo");
         img.setHeight("44px");
         appLayout.setBranding(img);
 
-        appLayout.addMenuItems(new AppLayoutMenuItem("Page 1", "page1"),
+        menu.addMenuItems(new AppLayoutMenuItem("Page 1", "page1"),
             new AppLayoutMenuItem("Page 2", "page2"),
             new AppLayoutMenuItem("Page 3", "page3"),
             new AppLayoutMenuItem("Page 4", "page4"));
@@ -61,8 +63,9 @@ public class AppLayoutView extends DemoView {
         // begin-source-example
         // source-example-heading: App Layout with Action Menu Item
         AppLayout appLayout = new AppLayout();
+        AppLayoutMenu menu = appLayout.createMenu();
 
-        appLayout.addMenuItems(
+        menu.addMenuItems(
             new AppLayoutMenuItem(VaadinIcon.USER.create(),"My Profile","profile"),
             new AppLayoutMenuItem(VaadinIcon.TRENDING_UP.create(),"Trending Topics","trends"),
             new AppLayoutMenuItem(VaadinIcon.SIGN_OUT.create(),"Sign Out", e -> logout()));

--- a/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AbstractAppRouterLayout.java
+++ b/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AbstractAppRouterLayout.java
@@ -27,14 +27,16 @@ import com.vaadin.flow.router.RouterLayout;
  * Basic usage involves extending this class and implementing
  * the {@code configure} method.
  *
- * @see AbstractAppRouterLayout#configure(AppLayout)
+ * @see AbstractAppRouterLayout#configure(AppLayout, AppLayoutMenu)
  */
 public abstract class AbstractAppRouterLayout implements RouterLayout {
 
     private AppLayout appLayout = new AppLayout();
 
+    private AppLayoutMenu appLayoutMenu = appLayout.createMenu();
+
     protected AbstractAppRouterLayout() {
-        configure(getAppLayout());
+        configure(getAppLayout(), getAppLayoutMenu());
     }
 
     /**
@@ -43,13 +45,14 @@ public abstract class AbstractAppRouterLayout implements RouterLayout {
      *
      * @param appLayout {@link AppLayout} to configure.
      */
-    protected abstract void configure(AppLayout appLayout);
+    protected abstract void configure(AppLayout appLayout,
+        AppLayoutMenu appLayoutMenu);
 
     /**
      * This hook is called when a navigation is being made into a route
      * which has this router layout as its parent layout.
      *
-     * @param route route that is being navigated to
+     * @param route   route that is being navigated to
      * @param content the content component
      */
     protected void onNavigate(String route, HasElement content) {
@@ -57,13 +60,13 @@ public abstract class AbstractAppRouterLayout implements RouterLayout {
 
     @Override
     public void showRouterLayoutContent(HasElement content) {
-        final String target = UI.getCurrent().getRouter().getUrl(
-                content.getElement().getComponent().get().getClass());
+        final String target = UI.getCurrent().getRouter()
+            .getUrl(content.getElement().getComponent().get().getClass());
 
         onNavigate(target, content);
 
-        getAppLayout().getMenuItemTargetingRoute(target)
-                .ifPresent(getAppLayout()::selectMenuItem);
+        getAppLayoutMenu().getMenuItemTargetingRoute(target)
+            .ifPresent(getAppLayoutMenu()::selectMenuItem);
         getAppLayout().setContent(content.getElement());
     }
 
@@ -77,5 +80,9 @@ public abstract class AbstractAppRouterLayout implements RouterLayout {
      */
     public AppLayout getAppLayout() {
         return appLayout;
+    }
+
+    public AppLayoutMenu getAppLayoutMenu() {
+        return appLayoutMenu;
     }
 }

--- a/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AbstractAppRouterLayout.java
+++ b/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AbstractAppRouterLayout.java
@@ -43,7 +43,8 @@ public abstract class AbstractAppRouterLayout implements RouterLayout {
      * This hook is called when this router layout is being constructed
      * and provides an opportunity to configure the AppLayout in use.
      *
-     * @param appLayout {@link AppLayout} to configure.
+     * @param appLayout {@link AppLayout} parent layout
+     * @param appLayoutMenu {@link AppLayoutMenu} to configure.
      */
     protected abstract void configure(AppLayout appLayout,
         AppLayoutMenu appLayoutMenu);
@@ -53,7 +54,7 @@ public abstract class AbstractAppRouterLayout implements RouterLayout {
      * which has this router layout as its parent layout.
      *
      * @param route   route that is being navigated to
-     * @param content the content component
+     * @param content {@link HasElement} the content component
      */
     protected void onNavigate(String route, HasElement content) {
     }
@@ -76,12 +77,16 @@ public abstract class AbstractAppRouterLayout implements RouterLayout {
     }
 
     /**
-     * Returns an application layout instance
+     * @return {@link AppLayout} parent layout
      */
     public AppLayout getAppLayout() {
         return appLayout;
     }
 
+    /**
+     *
+     * @return {@link AppLayoutMenu} which will be updated on navigation.
+     */
     public AppLayoutMenu getAppLayoutMenu() {
         return appLayoutMenu;
     }

--- a/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
+++ b/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
@@ -8,10 +8,10 @@ package com.vaadin.flow.component.applayout;
  * %%
  * This program is available under Commercial Vaadin Add-On License 3.0
  * (CVALv3).
- *
+ * 
  * See the file license.html distributed with this software for more
  * information about licensing.
- *
+ * 
  * You should have received a copy of the CVALv3 along with this program.
  * If not, see <http://vaadin.com/license/cval-3>.
  * #L%

--- a/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
+++ b/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
@@ -8,10 +8,10 @@ package com.vaadin.flow.component.applayout;
  * %%
  * This program is available under Commercial Vaadin Add-On License 3.0
  * (CVALv3).
- * 
+ *
  * See the file license.html distributed with this software for more
  * information about licensing.
- * 
+ *
  * You should have received a copy of the CVALv3 along with this program.
  * If not, see <http://vaadin.com/license/cval-3>.
  * #L%
@@ -40,7 +40,7 @@ public class AppLayout extends Component {
     /**
      * Sets the component into branding area
      *
-     * @param branding Component to set into branding area
+     * @param branding {@link Component} to set into branding area
      */
     public void setBranding(Component branding) {
         setBranding(toElement(branding));
@@ -49,7 +49,7 @@ public class AppLayout extends Component {
     /**
      * Sets the element into branding area
      *
-     * @param branding Element to set into branding area
+     * @param branding {@link Element} to set into branding area
      */
     public void setBranding(Element branding) {
         Objects.requireNonNull(branding, "Branding cannot be null");
@@ -71,7 +71,7 @@ public class AppLayout extends Component {
     }
 
     /**
-     * Returns a content
+     * Returns the {@link Element}
      */
     public Element getContent() {
         return content;
@@ -80,7 +80,7 @@ public class AppLayout extends Component {
     /**
      * Sets the displayed content.
      *
-     * @param content Component to display in the content area
+     * @param content {@link Component} to display in the content area
      */
     public void setContent(Component content) {
         setContent(toElement(content));
@@ -89,7 +89,7 @@ public class AppLayout extends Component {
     /**
      * Sets the displayed content.
      *
-     * @param content Element to display in the content area
+     * @param content {@link Element} to display in the content area
      */
     public void setContent(Element content) {
         Objects.requireNonNull(content, "Content cannot be null");
@@ -109,7 +109,7 @@ public class AppLayout extends Component {
     }
 
     /**
-     * @return the element at the menu slot.
+     * @return {@link Element} displayed at the content area.
      */
     public Element getMenu() {
         return menu;
@@ -118,7 +118,7 @@ public class AppLayout extends Component {
     /**
      * Sets the component to be placed in the menu slot.
      *
-     * @param menu Component to placed in the menu slot.
+     * @param menu {@link HasElement} to placed in the menu slot.
      */
     public void setMenu(HasElement menu) {
         setMenu(toElement(menu));
@@ -127,7 +127,7 @@ public class AppLayout extends Component {
     /**
      * Sets the element to be placed in the menu slot.
      *
-     * @param menu Element to placed in the menu slot.
+     * @param menu {@link Element} to placed in the menu slot.
      */
     public void setMenu(Element menu) {
         Objects.requireNonNull(menu, "Menu cannot be null");
@@ -141,7 +141,7 @@ public class AppLayout extends Component {
     /**
      * Creates a new empty AppLayoutMenu and sets it as the menu for this AppLayout instance.
      *
-     * @return AppLayoutMenu created.
+     * @return {@link AppLayoutMenu} created.
      */
     public AppLayoutMenu createMenu() {
         final AppLayoutMenu menu = new AppLayoutMenu();

--- a/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
+++ b/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
@@ -17,16 +17,13 @@ package com.vaadin.flow.component.applayout;
  * #L%
  */
 
-import com.helger.commons.annotation.VisibleForTesting;
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.dom.Element;
 
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * Server-side component for the {@code <vaadin-app-layout>} element.
@@ -38,15 +35,7 @@ public class AppLayout extends Component {
 
     private Element branding;
     private Element content;
-
-    private final AppLayoutMenu menuTabs = new AppLayoutMenu();
-
-    /**
-     * Initializes a new app layout with a default menu.
-     */
-    public AppLayout() {
-        getElement().appendChild(menuTabs.getElement());
-    }
+    private Element menu;
 
     /**
      * Sets the component into branding area
@@ -54,7 +43,7 @@ public class AppLayout extends Component {
      * @param branding Component to set into branding area
      */
     public void setBranding(Component branding) {
-        setBranding(branding != null ? branding.getElement() : null);
+        setBranding(toElement(branding));
     }
 
     /**
@@ -82,138 +71,6 @@ public class AppLayout extends Component {
     }
 
     /**
-     * Selects a menu item.
-     */
-    void selectMenuItem(AppLayoutMenuItem menuItem) {
-        menuTabs.selectMenuItem(menuItem);
-    }
-
-    /**
-     * Clears existing menu items and sets the new the arguments.
-     *
-     * @param menuItems menu items to set.
-     */
-    public void setMenuItems(AppLayoutMenuItem... menuItems) {
-        menuTabs.setMenuItems(menuItems);
-    }
-
-    /**
-     * Adds menu item to the menu
-     *
-     * @param menuItem Menu Item to add
-     */
-    public void addMenuItems(AppLayoutMenuItem... menuItem) {
-        menuTabs.addMenuItems(menuItem);
-    }
-
-    /**
-     * Constructs a new object with the given title.
-     *
-     * @param title the title to display
-     */
-    public AppLayoutMenuItem addMenuItem(String title) {
-        return addAndReturn(new AppLayoutMenuItem(title));
-    }
-
-    /**
-     * Constructs a new object with the given icon.
-     *
-     * @param icon the icon to display
-     */
-    public AppLayoutMenuItem addMenuItem(Component icon) {
-        return addAndReturn(new AppLayoutMenuItem(icon));
-    }
-
-    /**
-     * Constructs a new object with the given icon and title.
-     *
-     * @param icon  the icon to display
-     * @param title the title to display
-     */
-    public AppLayoutMenuItem addMenuItem(Component icon, String title) {
-        return addAndReturn(new AppLayoutMenuItem(icon, title));
-    }
-
-    /**
-     * Constructs a new object with the given icon, title and route.
-     *
-     * @param icon  the icon to display
-     * @param title the title to display
-     * @param route the route to navigate on click
-     */
-    public AppLayoutMenuItem addMenuItem(Component icon, String title,
-        String route) {
-        return addAndReturn(new AppLayoutMenuItem(icon, title, route));
-    }
-
-    /**
-     * Constructs a new object with the given icon and click listener.
-     *
-     * @param icon     the icon to display
-     * @param listener the menu item click listener
-     */
-    public AppLayoutMenuItem addMenuItem(Component icon,
-        ComponentEventListener<MenuItemClickEvent> listener) {
-        return addAndReturn(new AppLayoutMenuItem(icon, listener));
-    }
-
-    /**
-     * Constructs a new object with the given title and click listener.
-     *
-     * @param title    the title to display
-     * @param listener the menu item click listener
-     */
-    public AppLayoutMenuItem addMenuItem(String title,
-        ComponentEventListener<MenuItemClickEvent> listener) {
-        return addAndReturn(new AppLayoutMenuItem(title, listener));
-    }
-
-    /**
-     * Constructs a new object with the given icon, title and click listener.
-     *
-     * @param icon     the icon to display
-     * @param title    the title to display
-     * @param listener the menu item click listener
-     */
-    public AppLayoutMenuItem addMenuItem(Component icon, String title,
-        ComponentEventListener<MenuItemClickEvent> listener) {
-        return addAndReturn(new AppLayoutMenuItem(icon, title, listener));
-    }
-
-    private AppLayoutMenuItem addAndReturn(AppLayoutMenuItem item) {
-        addMenuItems(item);
-        return item;
-    }
-
-    /**
-     * Removes menu item from the menu
-     */
-    public void removeMenuItem(AppLayoutMenuItem menuItem) {
-        menuTabs.removeMenuItem(menuItem);
-    }
-
-    /**
-     * Removes all menu items.
-     */
-    public void clearMenuItems() {
-        menuTabs.clearMenuItems();
-    }
-
-    /**
-     * Gets the first {@link AppLayoutMenuItem} targeting a route.
-     */
-    Optional<AppLayoutMenuItem> getMenuItemTargetingRoute(String route) {
-        return menuTabs.getMenuItemTargetingRoute(route);
-    }
-
-    /**
-     * Gets the currently selected menu item.
-     */
-    public AppLayoutMenuItem getSelectedMenuItem() {
-        return menuTabs.getSelectedMenuItem();
-    }
-
-    /**
      * Returns a content
      */
     public Element getContent() {
@@ -226,7 +83,7 @@ public class AppLayout extends Component {
      * @param content Component to display in the content area
      */
     public void setContent(Component content) {
-        setContent(content != null ? content.getElement() : null);
+        setContent(toElement(content));
     }
 
     /**
@@ -251,14 +108,62 @@ public class AppLayout extends Component {
         this.content = null;
     }
 
+    /**
+     * @return the element at the menu slot.
+     */
+    public Element getMenu() {
+        return menu;
+    }
+
+    /**
+     * Sets the component to be placed in the menu slot.
+     *
+     * @param menu Component to placed in the menu slot.
+     */
+    public void setMenu(HasElement menu) {
+        setMenu(toElement(menu));
+    }
+
+    /**
+     * Sets the element to be placed in the menu slot.
+     *
+     * @param menu Element to placed in the menu slot.
+     */
+    public void setMenu(Element menu) {
+        Objects.requireNonNull(menu, "Menu cannot be null");
+
+        removeMenu();
+        this.menu = menu;
+        menu.setAttribute("slot", "menu");
+        getElement().appendChild(menu);
+    }
+
+    /**
+     * Creates a new empty AppLayoutMenu and sets it as the menu for this AppLayout instance.
+     *
+     * @return AppLayoutMenu created.
+     */
+    public AppLayoutMenu createMenu() {
+        final AppLayoutMenu menu = new AppLayoutMenu();
+        setMenu(menu);
+        return menu;
+    }
+
+    /**
+     * Remove the menu.
+     */
+    public void removeMenu() {
+        remove(this.menu);
+        this.menu = null;
+    }
+
     private void remove(Element element) {
         if (element != null) {
             element.removeFromParent();
         }
     }
 
-    @VisibleForTesting
-    HasElement getMenu() {
-        return menuTabs;
+    private static Element toElement(HasElement hasElement) {
+        return hasElement != null ? hasElement.getElement() : null;
     }
 }

--- a/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayoutMenu.java
+++ b/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayoutMenu.java
@@ -8,10 +8,10 @@ package com.vaadin.flow.component.applayout;
  * %%
  * This program is available under Commercial Vaadin Add-On License 3.0
  * (CVALv3).
- * 
+ *
  * See the file license.html distributed with this software for more
  * information about licensing.
- * 
+ *
  * You should have received a copy of the CVALv3 along with this program.
  * If not, see <http://vaadin.com/license/cval-3>.
  * #L%
@@ -68,7 +68,7 @@ public class AppLayoutMenu implements HasElement, AttachNotifier {
     /**
      * Clears existing menu items and sets the new the arguments.
      *
-     * @param menuItems items to set
+     * @param menuItems items of the type {@link AppLayoutMenuItem} to set
      */
     public void setMenuItems(AppLayoutMenuItem... menuItems) {
         clearMenuItems();
@@ -78,7 +78,7 @@ public class AppLayoutMenu implements HasElement, AttachNotifier {
     /**
      * Adds menu items to the menu.
      *
-     * @param menuItems items to add
+     * @param menuItems items of the type {@link AppLayoutMenuItem} to add
      */
     public void addMenuItems(AppLayoutMenuItem... menuItems) {
         tabs.add(menuItems);
@@ -164,7 +164,7 @@ public class AppLayoutMenu implements HasElement, AttachNotifier {
     }
 
     /**
-     * Removes menu item from the menu
+     * Removes {@link AppLayoutMenuItem} from the menu
      */
     public void removeMenuItem(AppLayoutMenuItem menuItem) {
         if (Objects.equals(this.selectedMenuItem, menuItem)) {
@@ -183,6 +183,8 @@ public class AppLayoutMenu implements HasElement, AttachNotifier {
 
     /**
      * Selects a menu item.
+     *
+     * @param menuItem {@link AppLayoutMenuItem} to select
      */
     public void selectMenuItem(AppLayoutMenuItem menuItem) {
         selectedMenuItem = menuItem;
@@ -191,6 +193,9 @@ public class AppLayoutMenu implements HasElement, AttachNotifier {
 
     /**
      * Gets the first {@link AppLayoutMenuItem} targeting a route.
+     *
+     * @param route route to match to {@link AppLayoutMenuItem#getRoute()}
+     * @return {@link AppLayoutMenuItem} wrapped in an {@link Optional}, if found.
      */
     public Optional<AppLayoutMenuItem> getMenuItemTargetingRoute(String route) {
         Objects.requireNonNull(route, "Route can not be null");
@@ -200,6 +205,8 @@ public class AppLayoutMenu implements HasElement, AttachNotifier {
 
     /**
      * Gets the currently selected menu item.
+     *
+     * @return {@link AppLayoutMenuItem} selected menu item.
      */
     public AppLayoutMenuItem getSelectedMenuItem() {
         return selectedMenuItem;

--- a/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayoutMenu.java
+++ b/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayoutMenu.java
@@ -8,10 +8,10 @@ package com.vaadin.flow.component.applayout;
  * %%
  * This program is available under Commercial Vaadin Add-On License 3.0
  * (CVALv3).
- *
+ * 
  * See the file license.html distributed with this software for more
  * information about licensing.
- *
+ * 
  * You should have received a copy of the CVALv3 along with this program.
  * If not, see <http://vaadin.com/license/cval-3>.
  * #L%

--- a/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayoutMenu.java
+++ b/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayoutMenu.java
@@ -18,6 +18,8 @@ package com.vaadin.flow.component.applayout;
  */
 
 import com.vaadin.flow.component.AttachNotifier;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.tabs.Tabs;
 import com.vaadin.flow.dom.Element;
@@ -26,19 +28,18 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * Tabs for AppLayout.
+ * Menu to be used with AppLayout. Provides clicable tabs that can be used for routing or individual actions.
  */
-class AppLayoutMenu implements HasElement, AttachNotifier {
+public class AppLayoutMenu implements HasElement, AttachNotifier {
 
     private final Tabs tabs = new Tabs();
     private AppLayoutMenuItem selectedMenuItem;
 
     /**
-     * Initializes a new app layout with a default menu.
+     * Default constructor.
      */
-    AppLayoutMenu() {
-        getElement().setAttribute("slot", "menu");
-        getElement().setAttribute("theme", "minimal");
+    public AppLayoutMenu() {
+        tabs.getElement().setAttribute("theme", "minimal");
 
         tabs.addAttachListener(attachEvent -> {
             tabs.setSelectedTab(selectedMenuItem);
@@ -69,7 +70,7 @@ class AppLayoutMenu implements HasElement, AttachNotifier {
      *
      * @param menuItems items to set
      */
-    void setMenuItems(AppLayoutMenuItem... menuItems) {
+    public void setMenuItems(AppLayoutMenuItem... menuItems) {
         clearMenuItems();
         addMenuItems(menuItems);
     }
@@ -79,14 +80,93 @@ class AppLayoutMenu implements HasElement, AttachNotifier {
      *
      * @param menuItems items to add
      */
-    void addMenuItems(AppLayoutMenuItem... menuItems) {
+    public void addMenuItems(AppLayoutMenuItem... menuItems) {
         tabs.add(menuItems);
+    }
+
+    /**
+     * Constructs a new object with the given title.
+     *
+     * @param title the title to display
+     */
+    public AppLayoutMenuItem addMenuItem(String title) {
+        return addAndReturn(new AppLayoutMenuItem(title));
+    }
+
+    /**
+     * Constructs a new object with the given icon.
+     *
+     * @param icon the icon to display
+     */
+    public AppLayoutMenuItem addMenuItem(Component icon) {
+        return addAndReturn(new AppLayoutMenuItem(icon));
+    }
+
+    /**
+     * Constructs a new object with the given icon and title.
+     *
+     * @param icon  the icon to display
+     * @param title the title to display
+     */
+    public AppLayoutMenuItem addMenuItem(Component icon, String title) {
+        return addAndReturn(new AppLayoutMenuItem(icon, title));
+    }
+
+    /**
+     * Constructs a new object with the given icon, title and route.
+     *
+     * @param icon  the icon to display
+     * @param title the title to display
+     * @param route the route to navigate on click
+     */
+    public AppLayoutMenuItem addMenuItem(Component icon, String title,
+        String route) {
+        return addAndReturn(new AppLayoutMenuItem(icon, title, route));
+    }
+
+    /**
+     * Constructs a new object with the given icon and click listener.
+     *
+     * @param icon     the icon to display
+     * @param listener the menu item click listener
+     */
+    public AppLayoutMenuItem addMenuItem(Component icon,
+        ComponentEventListener<MenuItemClickEvent> listener) {
+        return addAndReturn(new AppLayoutMenuItem(icon, listener));
+    }
+
+    /**
+     * Constructs a new object with the given title and click listener.
+     *
+     * @param title    the title to display
+     * @param listener the menu item click listener
+     */
+    public AppLayoutMenuItem addMenuItem(String title,
+        ComponentEventListener<MenuItemClickEvent> listener) {
+        return addAndReturn(new AppLayoutMenuItem(title, listener));
+    }
+
+    /**
+     * Constructs a new object with the given icon, title and click listener.
+     *
+     * @param icon     the icon to display
+     * @param title    the title to display
+     * @param listener the menu item click listener
+     */
+    public AppLayoutMenuItem addMenuItem(Component icon, String title,
+        ComponentEventListener<MenuItemClickEvent> listener) {
+        return addAndReturn(new AppLayoutMenuItem(icon, title, listener));
+    }
+
+    private AppLayoutMenuItem addAndReturn(AppLayoutMenuItem item) {
+        addMenuItems(item);
+        return item;
     }
 
     /**
      * Removes menu item from the menu
      */
-    void removeMenuItem(AppLayoutMenuItem menuItem) {
+    public void removeMenuItem(AppLayoutMenuItem menuItem) {
         if (Objects.equals(this.selectedMenuItem, menuItem)) {
             this.selectedMenuItem = null;
         }
@@ -104,21 +184,30 @@ class AppLayoutMenu implements HasElement, AttachNotifier {
     /**
      * Selects a menu item.
      */
-    void selectMenuItem(AppLayoutMenuItem menuItem) {
+    public void selectMenuItem(AppLayoutMenuItem menuItem) {
         selectedMenuItem = menuItem;
         tabs.setSelectedTab(menuItem);
     }
 
-    Optional<AppLayoutMenuItem> getMenuItemTargetingRoute(String route) {
+    /**
+     * Gets the first {@link AppLayoutMenuItem} targeting a route.
+     */
+    public Optional<AppLayoutMenuItem> getMenuItemTargetingRoute(String route) {
         Objects.requireNonNull(route, "Route can not be null");
         return tabs.getChildren().map(AppLayoutMenuItem.class::cast)
             .filter(e -> route.equals(e.getRoute())).findFirst();
     }
 
-    AppLayoutMenuItem getSelectedMenuItem() {
+    /**
+     * Gets the currently selected menu item.
+     */
+    public AppLayoutMenuItem getSelectedMenuItem() {
         return selectedMenuItem;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Element getElement() {
         return tabs.getElement();

--- a/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayoutMenuItem.java
+++ b/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayoutMenuItem.java
@@ -176,7 +176,7 @@ public class AppLayoutMenuItem extends Tab {
     /**
      * Sets the route to be navigated to when this menu item is selected.
      *
-     * @param route
+     * @param route Route to be navigated to
      */
     public void setRoute(String route) {
         this.route = route;

--- a/vaadin-app-layout-flow/src/test/java/com/vaadin/flow/component/applayout/AbstractAppRouterLayoutTest.java
+++ b/vaadin-app-layout-flow/src/test/java/com/vaadin/flow/component/applayout/AbstractAppRouterLayoutTest.java
@@ -26,7 +26,8 @@ public class AbstractAppRouterLayoutTest {
     public class TestAppRouterLayout extends AbstractAppRouterLayout {
 
         @Override
-        protected void configure(AppLayout appLayout) {
+        protected void configure(AppLayout appLayout,
+            AppLayoutMenu appLayoutMenu) {
             events.add("Configured");
         }
 
@@ -67,7 +68,7 @@ public class AbstractAppRouterLayoutTest {
 
         AppLayoutMenuItem route1MenuItem = new AppLayoutMenuItem("Route 1",
             "route1");
-        systemUnderTest.getAppLayout().addMenuItems(route1MenuItem,
+        systemUnderTest.getAppLayoutMenu().addMenuItems(route1MenuItem,
             new AppLayoutMenuItem("Dummy", "dummy"));
 
         Route1 route1 = new Route1();
@@ -81,7 +82,7 @@ public class AbstractAppRouterLayoutTest {
 
         // Ensure the matching menu item is selected
         Assert.assertEquals(route1MenuItem,
-            systemUnderTest.getAppLayout().getSelectedMenuItem());
+            systemUnderTest.getAppLayoutMenu().getSelectedMenuItem());
         Assert.assertEquals(route1.getElement(),
             systemUnderTest.getAppLayout().getContent());
 
@@ -90,7 +91,7 @@ public class AbstractAppRouterLayoutTest {
 
         // Ensure selected menu item remains unchanged
         Assert.assertEquals(route1MenuItem,
-            systemUnderTest.getAppLayout().getSelectedMenuItem());
+            systemUnderTest.getAppLayoutMenu().getSelectedMenuItem());
     }
 
     private void setupFlowRouting() {

--- a/vaadin-app-layout-flow/src/test/java/com/vaadin/flow/component/applayout/AppLayoutMenuTest.java
+++ b/vaadin-app-layout-flow/src/test/java/com/vaadin/flow/component/applayout/AppLayoutMenuTest.java
@@ -2,11 +2,17 @@ package com.vaadin.flow.component.applayout;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.tabs.Tabs;
+import com.vaadin.flow.dom.Element;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.stream.Stream;
 
 public class AppLayoutMenuTest {
     private AppLayoutMenu systemUnderTest;
@@ -14,12 +20,6 @@ public class AppLayoutMenuTest {
     @Before
     public void setUp() {
         systemUnderTest = new AppLayoutMenu();
-    }
-
-    @Test
-    public void construction_elementIsInMenuSlot() {
-        Assert.assertEquals("menu",
-            systemUnderTest.getElement().getAttribute("slot"));
     }
 
     @Test
@@ -45,6 +45,209 @@ public class AppLayoutMenuTest {
 
         // No menu item is selected by default.
         Assert.assertEquals(home, systemUnderTest.getSelectedMenuItem());
+    }
+
+
+    @Test
+    public void setMenuItems() {
+        Assert.assertEquals(0, systemUnderTest.getElement().getChildCount());
+
+        systemUnderTest.addMenuItems(new AppLayoutMenuItem("Home", ""));
+
+        AppLayoutMenuItem[] newMenuItems = Stream
+            .generate(() -> new AppLayoutMenuItem("Route", "route")).limit(3)
+            .toArray(AppLayoutMenuItem[]::new);
+
+        systemUnderTest.setMenuItems(newMenuItems);
+
+        Assert.assertEquals(newMenuItems.length, systemUnderTest.getElement().getChildCount());
+    }
+
+    @Test
+    public void addMenuItems() {
+        Assert.assertEquals(0, systemUnderTest.getElement().getChildCount());
+
+        systemUnderTest.addMenuItems(new AppLayoutMenuItem("Home", ""));
+        Assert.assertEquals(1, systemUnderTest.getElement().getChildCount());
+    }
+
+    @Test
+    public void removeMenuItem() {
+        AppLayoutMenuItem home = new AppLayoutMenuItem("Home", "");
+        systemUnderTest.addMenuItems(home);
+        Assert.assertEquals(1, systemUnderTest.getElement().getChildCount());
+
+        systemUnderTest.removeMenuItem(home);
+        Assert.assertEquals(0, systemUnderTest.getElement().getChildCount());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void removeMenuItem_invalidItem() {
+        AppLayoutMenuItem home = new AppLayoutMenuItem("Home", "");
+        systemUnderTest.addMenuItems(home);
+
+        Tabs otherTabs = new Tabs();
+        AppLayoutMenuItem otherMenuItem = new AppLayoutMenuItem("Profile",
+            "profile");
+        otherTabs.add(otherMenuItem);
+
+        systemUnderTest.removeMenuItem(otherMenuItem);
+    }
+
+    @Test
+    public void getMenuItemTargetingRoute() {
+        AppLayoutMenuItem home = new AppLayoutMenuItem("Home", "");
+        AppLayoutMenuItem profile = new AppLayoutMenuItem("Profile", "profile");
+        AppLayoutMenuItem settings = new AppLayoutMenuItem("Settings",
+            "settings");
+        systemUnderTest.addMenuItems(home, profile, settings);
+
+        Assert.assertEquals(profile,
+            systemUnderTest.getMenuItemTargetingRoute("profile").get());
+    }
+
+    @Test
+    public void getMenuItemTargetingRoute_none() {
+        AppLayoutMenuItem home = new AppLayoutMenuItem("Home", "");
+        AppLayoutMenuItem profile = new AppLayoutMenuItem("Profile", "profile");
+        systemUnderTest.addMenuItems(home, profile);
+
+        Assert.assertFalse(
+            systemUnderTest.getMenuItemTargetingRoute("dashboard").isPresent());
+    }
+
+    @Test
+    public void getMenuItemTargetingRoute_duplicate() {
+        AppLayoutMenuItem profile = new AppLayoutMenuItem("Profile", "profile");
+        AppLayoutMenuItem settings = new AppLayoutMenuItem("Settings",
+            "profile");
+        systemUnderTest.addMenuItems(profile, settings);
+
+        Assert.assertEquals(profile,
+            systemUnderTest.getMenuItemTargetingRoute("profile").get());
+    }
+
+    @Test
+    public void selectMenuItem() {
+        AppLayoutMenuItem home = new AppLayoutMenuItem("Home", "");
+        AppLayoutMenuItem profile = new AppLayoutMenuItem("Profile", "profile");
+        AppLayoutMenuItem logout = new AppLayoutMenuItem("Logout");
+        systemUnderTest.addMenuItems(home, profile, logout);
+
+        final Tabs tabs = (Tabs) systemUnderTest.getElement()
+            .getComponent().get();
+        ComponentUtil.fireEvent(tabs, new AttachEvent(tabs, true));
+        Assert.assertNull(tabs.getSelectedTab());
+
+        systemUnderTest.selectMenuItem(profile);
+
+        Assert.assertEquals(profile, tabs.getSelectedTab());
+    }
+
+    @Test
+    public void setMenuItems_after_calling_addMenuItems() {
+        systemUnderTest.addMenuItems(new AppLayoutMenuItem("Action1"));
+        systemUnderTest.setMenuItems(new AppLayoutMenuItem("Action2"),
+            new AppLayoutMenuItem("Action3"));
+        Assert.assertArrayEquals(new Object[] { "Action2", "Action3" },
+            systemUnderTest.getElement().getChildren()
+                .map(e -> (AppLayoutMenuItem) e.getComponent().get())
+                .map(AppLayoutMenuItem::getTitle).toArray());
+    }
+
+    @Test
+    public void clearMenuItems() {
+        Assert.assertEquals(0,
+            systemUnderTest.getElement().getChildCount());
+        //No exception on clearing already empty.
+        systemUnderTest.clearMenuItems();
+        systemUnderTest.setMenuItems(new AppLayoutMenuItem("Action1"),
+            new AppLayoutMenuItem("Action2"));
+        Assert.assertEquals(2,
+            systemUnderTest.getElement().getChildCount());
+
+        systemUnderTest.clearMenuItems();
+        Assert.assertEquals(0,
+            systemUnderTest.getElement().getChildCount());
+
+    }
+
+    @Test
+    public void addMenuItem_title() {
+        final String title = "Title";
+        AppLayoutMenuItem appLayoutMenuItem = systemUnderTest
+            .addMenuItem(title);
+        Assert.assertEquals(title, appLayoutMenuItem.getTitle());
+    }
+
+    @Test
+    public void addMenuItem_icon() {
+        final Component icon = new Div();
+        AppLayoutMenuItem appLayoutMenuItem = systemUnderTest.addMenuItem(icon);
+        Assert.assertEquals(icon, appLayoutMenuItem.getIcon());
+    }
+
+    @Test
+    public void addMenuItem_icon_and_title() {
+        final Component icon = new Div();
+        final String title = "Title";
+        AppLayoutMenuItem appLayoutMenuItem = systemUnderTest
+            .addMenuItem(icon, title);
+        Assert.assertEquals(icon, appLayoutMenuItem.getIcon());
+        Assert.assertEquals(title, appLayoutMenuItem.getTitle());
+    }
+
+    @Test
+    public void addMenuItem_icon_title_and_route() {
+        final Component icon = new Div();
+        final String title = "Title";
+        final String route = "route";
+        AppLayoutMenuItem appLayoutMenuItem = systemUnderTest
+            .addMenuItem(icon, title, route);
+        Assert.assertEquals(icon, appLayoutMenuItem.getIcon());
+        Assert.assertEquals(title, appLayoutMenuItem.getTitle());
+        Assert.assertEquals(route, appLayoutMenuItem.getRoute());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void addMenuItem_icon_listener() {
+        final Component icon = new Div();
+        final ComponentEventListener<MenuItemClickEvent> listener = (ComponentEventListener<MenuItemClickEvent>) Mockito
+            .mock(ComponentEventListener.class);
+        AppLayoutMenuItem appLayoutMenuItem = systemUnderTest
+            .addMenuItem(icon, listener);
+        Assert.assertEquals(icon, appLayoutMenuItem.getIcon());
+        appLayoutMenuItem.fireMenuItemClickEvent();
+        Mockito.verify(listener).onComponentEvent(Mockito.any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void addMenuItem_title_listener() {
+        final String title = "Title";
+        final ComponentEventListener<MenuItemClickEvent> listener = (ComponentEventListener<MenuItemClickEvent>) Mockito
+            .mock(ComponentEventListener.class);
+        AppLayoutMenuItem appLayoutMenuItem = systemUnderTest
+            .addMenuItem(title, listener);
+        Assert.assertEquals(title, appLayoutMenuItem.getTitle());
+        appLayoutMenuItem.fireMenuItemClickEvent();
+        Mockito.verify(listener).onComponentEvent(Mockito.any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void addMenuItem_icon_title_and_listener() {
+        final Component icon = new Div();
+        final String title = "Title";
+        final ComponentEventListener<MenuItemClickEvent> listener = (ComponentEventListener<MenuItemClickEvent>) Mockito
+            .mock(ComponentEventListener.class);
+        AppLayoutMenuItem appLayoutMenuItem = systemUnderTest
+            .addMenuItem(icon, title, listener);
+        Assert.assertEquals(icon, appLayoutMenuItem.getIcon());
+        Assert.assertEquals(title, appLayoutMenuItem.getTitle());
+        appLayoutMenuItem.fireMenuItemClickEvent();
+        Mockito.verify(listener).onComponentEvent(Mockito.any());
     }
 
 }

--- a/vaadin-app-layout-flow/src/test/java/com/vaadin/flow/component/applayout/AppLayoutTest.java
+++ b/vaadin-app-layout-flow/src/test/java/com/vaadin/flow/component/applayout/AppLayoutTest.java
@@ -1,21 +1,15 @@
 package com.vaadin.flow.component.applayout;
 
-import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
-import com.vaadin.flow.component.tabs.Tabs;
 import com.vaadin.flow.dom.Element;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class AppLayoutTest {
 
@@ -60,108 +54,6 @@ public class AppLayoutTest {
     }
 
     @Test
-    public void setMenuItems() {
-        Assert.assertEquals(0, getMenu().getChildCount());
-
-        systemUnderTest.addMenuItems(new AppLayoutMenuItem("Home", ""));
-
-        AppLayoutMenuItem[] newMenuItems = Stream
-            .generate(() -> new AppLayoutMenuItem("Route", "route")).limit(3)
-            .toArray(AppLayoutMenuItem[]::new);
-
-        systemUnderTest.setMenuItems(newMenuItems);
-
-        Assert.assertEquals(newMenuItems.length, getMenu().getChildCount());
-    }
-
-    @Test
-    public void addMenuItems() {
-        Assert.assertEquals(0, getMenu().getChildCount());
-
-        systemUnderTest.addMenuItems(new AppLayoutMenuItem("Home", ""));
-        Assert.assertEquals(1, getMenu().getChildCount());
-    }
-
-    private Element getMenu() {
-        return systemUnderTest.getChildren().map(Component::getElement)
-            .filter(e -> e.getAttribute("slot").equals("menu")).findFirst()
-            .get();
-    }
-
-    @Test
-    public void removeMenuItem() {
-        AppLayoutMenuItem home = new AppLayoutMenuItem("Home", "");
-        systemUnderTest.addMenuItems(home);
-        Assert.assertEquals(1, getMenu().getChildCount());
-
-        systemUnderTest.removeMenuItem(home);
-        Assert.assertEquals(0, getMenu().getChildCount());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void removeMenuItem_invalidItem() {
-        AppLayoutMenuItem home = new AppLayoutMenuItem("Home", "");
-        systemUnderTest.addMenuItems(home);
-
-        Tabs otherTabs = new Tabs();
-        AppLayoutMenuItem otherMenuItem = new AppLayoutMenuItem("Profile",
-            "profile");
-        otherTabs.add(otherMenuItem);
-
-        systemUnderTest.removeMenuItem(otherMenuItem);
-    }
-
-    @Test
-    public void getMenuItemTargetingRoute() {
-        AppLayoutMenuItem home = new AppLayoutMenuItem("Home", "");
-        AppLayoutMenuItem profile = new AppLayoutMenuItem("Profile", "profile");
-        AppLayoutMenuItem settings = new AppLayoutMenuItem("Settings",
-            "settings");
-        systemUnderTest.addMenuItems(home, profile, settings);
-
-        Assert.assertEquals(profile,
-            systemUnderTest.getMenuItemTargetingRoute("profile").get());
-    }
-
-    @Test
-    public void getMenuItemTargetingRoute_none() {
-        AppLayoutMenuItem home = new AppLayoutMenuItem("Home", "");
-        AppLayoutMenuItem profile = new AppLayoutMenuItem("Profile", "profile");
-        systemUnderTest.addMenuItems(home, profile);
-
-        Assert.assertFalse(
-            systemUnderTest.getMenuItemTargetingRoute("dashboard").isPresent());
-    }
-
-    @Test
-    public void getMenuItemTargetingRoute_duplicate() {
-        AppLayoutMenuItem profile = new AppLayoutMenuItem("Profile", "profile");
-        AppLayoutMenuItem settings = new AppLayoutMenuItem("Settings",
-            "profile");
-        systemUnderTest.addMenuItems(profile, settings);
-
-        Assert.assertEquals(profile,
-            systemUnderTest.getMenuItemTargetingRoute("profile").get());
-    }
-
-    @Test
-    public void selectMenuItem() {
-        AppLayoutMenuItem home = new AppLayoutMenuItem("Home", "");
-        AppLayoutMenuItem profile = new AppLayoutMenuItem("Profile", "profile");
-        AppLayoutMenuItem logout = new AppLayoutMenuItem("Logout");
-        systemUnderTest.addMenuItems(home, profile, logout);
-
-        final Tabs tabs = (Tabs) systemUnderTest.getMenu().getElement()
-            .getComponent().get();
-        ComponentUtil.fireEvent(tabs, new AttachEvent(tabs, true));
-        Assert.assertNull(tabs.getSelectedTab());
-
-        systemUnderTest.selectMenuItem(profile);
-
-        Assert.assertEquals(profile, tabs.getSelectedTab());
-    }
-
-    @Test
     public void setContent() {
         Element content = new Div().getElement();
         systemUnderTest.setContent(content);
@@ -184,112 +76,6 @@ public class AppLayoutTest {
             .collect(Collectors.toList());
         Assert.assertFalse(children.contains(content));
         Assert.assertNull(systemUnderTest.getContent());
-    }
-
-    @Test
-    public void setMenuItems_after_calling_addMenuItems() {
-        systemUnderTest.addMenuItems(new AppLayoutMenuItem("Action1"));
-        systemUnderTest.setMenuItems(new AppLayoutMenuItem("Action2"),
-            new AppLayoutMenuItem("Action3"));
-        Assert.assertArrayEquals(new Object[] { "Action2", "Action3" },
-            systemUnderTest.getMenu().getElement().getChildren()
-                .map(e -> (AppLayoutMenuItem) e.getComponent().get())
-                .map(AppLayoutMenuItem::getTitle).toArray());
-    }
-
-    @Test
-    public void clearMenuItems() {
-        Assert.assertEquals(0,
-            systemUnderTest.getMenu().getElement().getChildCount());
-        //No exception on clearing already empty.
-        systemUnderTest.clearMenuItems();
-        systemUnderTest.setMenuItems(new AppLayoutMenuItem("Action1"),
-            new AppLayoutMenuItem("Action2"));
-        Assert.assertEquals(2,
-            systemUnderTest.getMenu().getElement().getChildCount());
-
-        systemUnderTest.clearMenuItems();
-        Assert.assertEquals(0,
-            systemUnderTest.getMenu().getElement().getChildCount());
-
-    }
-
-    @Test
-    public void addMenuItem_title() {
-        final String title = "Title";
-        AppLayoutMenuItem appLayoutMenuItem = systemUnderTest
-            .addMenuItem(title);
-        Assert.assertEquals(title, appLayoutMenuItem.getTitle());
-    }
-
-    @Test
-    public void addMenuItem_icon() {
-        final Component icon = new Div();
-        AppLayoutMenuItem appLayoutMenuItem = systemUnderTest.addMenuItem(icon);
-        Assert.assertEquals(icon, appLayoutMenuItem.getIcon());
-    }
-
-    @Test
-    public void addMenuItem_icon_and_title() {
-        final Component icon = new Div();
-        final String title = "Title";
-        AppLayoutMenuItem appLayoutMenuItem = systemUnderTest
-            .addMenuItem(icon, title);
-        Assert.assertEquals(icon, appLayoutMenuItem.getIcon());
-        Assert.assertEquals(title, appLayoutMenuItem.getTitle());
-    }
-
-    @Test
-    public void addMenuItem_icon_title_and_route() {
-        final Component icon = new Div();
-        final String title = "Title";
-        final String route = "route";
-        AppLayoutMenuItem appLayoutMenuItem = systemUnderTest
-            .addMenuItem(icon, title, route);
-        Assert.assertEquals(icon, appLayoutMenuItem.getIcon());
-        Assert.assertEquals(title, appLayoutMenuItem.getTitle());
-        Assert.assertEquals(route, appLayoutMenuItem.getRoute());
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void addMenuItem_icon_listener() {
-        final Component icon = new Div();
-        final ComponentEventListener<MenuItemClickEvent> listener = (ComponentEventListener<MenuItemClickEvent>) Mockito
-            .mock(ComponentEventListener.class);
-        AppLayoutMenuItem appLayoutMenuItem = systemUnderTest
-            .addMenuItem(icon, listener);
-        Assert.assertEquals(icon, appLayoutMenuItem.getIcon());
-        appLayoutMenuItem.fireMenuItemClickEvent();
-        Mockito.verify(listener).onComponentEvent(Mockito.any());
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void addMenuItem_title_listener() {
-        final String title = "Title";
-        final ComponentEventListener<MenuItemClickEvent> listener = (ComponentEventListener<MenuItemClickEvent>) Mockito
-            .mock(ComponentEventListener.class);
-        AppLayoutMenuItem appLayoutMenuItem = systemUnderTest
-            .addMenuItem(title, listener);
-        Assert.assertEquals(title, appLayoutMenuItem.getTitle());
-        appLayoutMenuItem.fireMenuItemClickEvent();
-        Mockito.verify(listener).onComponentEvent(Mockito.any());
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void addMenuItem_icon_title_and_listener() {
-        final Component icon = new Div();
-        final String title = "Title";
-        final ComponentEventListener<MenuItemClickEvent> listener = (ComponentEventListener<MenuItemClickEvent>) Mockito
-            .mock(ComponentEventListener.class);
-        AppLayoutMenuItem appLayoutMenuItem = systemUnderTest
-            .addMenuItem(icon, title, listener);
-        Assert.assertEquals(icon, appLayoutMenuItem.getIcon());
-        Assert.assertEquals(title, appLayoutMenuItem.getTitle());
-        appLayoutMenuItem.fireMenuItemClickEvent();
-        Mockito.verify(listener).onComponentEvent(Mockito.any());
     }
 
 }

--- a/vaadin-app-layout-integration-tests/src/main/java/com/vaadin/flow/component/applayout/examples/AppRouterLayout.java
+++ b/vaadin-app-layout-integration-tests/src/main/java/com/vaadin/flow/component/applayout/examples/AppRouterLayout.java
@@ -3,6 +3,7 @@ package com.vaadin.flow.component.applayout.examples;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.applayout.AbstractAppRouterLayout;
 import com.vaadin.flow.component.applayout.AppLayout;
+import com.vaadin.flow.component.applayout.AppLayoutMenu;
 import com.vaadin.flow.component.applayout.AppLayoutMenuItem;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.icon.VaadinIcon;
@@ -21,19 +22,19 @@ import java.util.stream.IntStream;
 public class AppRouterLayout extends AbstractAppRouterLayout {
 
     @Override
-    protected void configure(AppLayout appLayout) {
+    protected void configure(AppLayout appLayout, AppLayoutMenu appLayoutMenu) {
         appLayout.setBranding(new Span("Vaadin").getElement());
 
-        appLayout.addMenuItems(generateMenuItems(
+        appLayoutMenu.addMenuItems(generateMenuItems(
             i -> new AppLayoutMenuItem(VaadinIcon.SAFE_LOCK.create(),
                 "Action " + i, e -> Notification
                 .show(e.getSource().getTitle() + " executed!"))));
 
-        appLayout.addMenuItems(generateMenuItems(
+        appLayoutMenu.addMenuItems(generateMenuItems(
             i -> (new AppLayoutMenuItem(VaadinIcon.LOCATION_ARROW.create(),
                 "Page " + i, "Page" + i))));
 
-        appLayout.addMenuItems(
+        appLayoutMenu.addMenuItems(
             new AppLayoutMenuItem(VaadinIcon.HOME.create(), "Home", ""),
             new AppLayoutMenuItem(VaadinIcon.USER.create(), "Logout",
                 e -> UI.getCurrent().navigate("LoggedOut")));


### PR DESCRIPTION
This enables to use any element in the slot menu. In order to implement this, all logic related to the menu was moved to the AppLayoutMenu class, which was made public. 

closes #20

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-app-layout-flow/36)
<!-- Reviewable:end -->
