### PR TITLE
Support testing menus with RouterLinks or other elements

### DIFF
--- a/vaadin-app-layout-integration-tests/src/main/java/com/vaadin/flow/component/applayout/examples/AppRouterLayoutWithRouterLinks.java
+++ b/vaadin-app-layout-integration-tests/src/main/java/com/vaadin/flow/component/applayout/examples/AppRouterLayoutWithRouterLinks.java
@@ -1,0 +1,30 @@
+package com.vaadin.flow.component.applayout.examples;
+
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.applayout.AppLayout;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.router.RouterLink;
+
+public class AppRouterLayoutWithRouterLinks extends Div
+    implements RouterLayout {
+
+    private final AppLayout appLayout = new AppLayout();
+
+    public AppRouterLayoutWithRouterLinks() {
+        appLayout.setBranding(VaadinIcon.VAADIN_H.create());
+        RouterLink link1 = new RouterLink("Page 3", Page3.class);
+        RouterLink link2 = new RouterLink("Page 4", Page4.class);
+        RouterLink link3 = new RouterLink("LoggedOut", LoggedOut.class);
+        appLayout.setMenu(new HorizontalLayout(link1,link2,link3));
+        add(appLayout);
+    }
+
+    @Override
+    public void showRouterLayoutContent(HasElement content) {
+        appLayout.setContent(content.getElement());
+    }
+
+}

--- a/vaadin-app-layout-integration-tests/src/main/java/com/vaadin/flow/component/applayout/examples/Page3.java
+++ b/vaadin-app-layout-integration-tests/src/main/java/com/vaadin/flow/component/applayout/examples/Page3.java
@@ -1,0 +1,12 @@
+package com.vaadin.flow.component.applayout.examples;
+
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "Page3", layout = AppRouterLayoutWithRouterLinks.class)
+public class Page3 extends Div {
+    public Page3() {
+        add(new Text("This is Page 3"));
+    }
+}

--- a/vaadin-app-layout-integration-tests/src/main/java/com/vaadin/flow/component/applayout/examples/Page4.java
+++ b/vaadin-app-layout-integration-tests/src/main/java/com/vaadin/flow/component/applayout/examples/Page4.java
@@ -1,0 +1,12 @@
+package com.vaadin.flow.component.applayout.examples;
+
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "Page4", layout = AppRouterLayoutWithRouterLinks.class)
+public class Page4 extends Div {
+    public Page4() {
+        add(new Text("This is Page 4"));
+    }
+}

--- a/vaadin-app-layout-integration-tests/src/test/java/com/vaadin/flow/component/applayout/test/AppLayoutIT.java
+++ b/vaadin-app-layout-integration-tests/src/test/java/com/vaadin/flow/component/applayout/test/AppLayoutIT.java
@@ -3,6 +3,9 @@ package com.vaadin.flow.component.applayout.test;
 import com.vaadin.flow.component.applayout.testbench.AppLayoutElement;
 import com.vaadin.flow.component.applayout.testbench.MenuItemElement;
 import com.vaadin.flow.component.notification.testbench.NotificationElement;
+import com.vaadin.flow.component.orderedlayout.testbench.HorizontalLayoutElement;
+import com.vaadin.flow.router.RouterLink;
+import com.vaadin.testbench.TestBenchElement;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,13 +32,13 @@ public class AppLayoutIT extends AbstractParallelTest {
     @Test
     public void countMenuItems() {
         Assert.assertEquals(6,
-                $(AppLayoutElement.class).waitForFirst().countMenuItems());
+                $(AppLayoutElement.class).waitForFirst().getAppLayoutMenuElement().countMenuItems());
     }
 
     @Test
     public void menuItemsByIndex() {
         MenuItemElement menuItem =
-                $(AppLayoutElement.class).waitForFirst().getMenuItemAt(1);
+                $(AppLayoutElement.class).waitForFirst().getAppLayoutMenuElement().getMenuItemAt(1);
         Assert.assertEquals("Action 2", menuItem.getTitle());
         Assert.assertEquals("vaadin:safe-lock", menuItem.getIcon().getAttribute("icon"));
     }
@@ -43,7 +46,7 @@ public class AppLayoutIT extends AbstractParallelTest {
     @Test
     public void menuItemsByTitle() {
         MenuItemElement menuItem =
-                $(AppLayoutElement.class).waitForFirst().getMenuItemWithTitle("Page 1");
+                $(AppLayoutElement.class).waitForFirst().getAppLayoutMenuElement().getMenuItemWithTitle("Page 1");
         Assert.assertEquals("Page 1", menuItem.getTitle());
         Assert.assertEquals("vaadin:location-arrow", menuItem.getIcon().getAttribute("icon"));
     }
@@ -51,20 +54,20 @@ public class AppLayoutIT extends AbstractParallelTest {
     @Test
     public void selectedMenuItem() {
         MenuItemElement selectedMenuItem =
-                $(AppLayoutElement.class).waitForFirst().getSelectedMenuItem();
+                $(AppLayoutElement.class).waitForFirst().getAppLayoutMenuElement().getSelectedMenuItem();
         Assert.assertEquals("Home", selectedMenuItem.getTitle());
     }
 
     @Test
     public void actionMenuItems_executeAction() {
         MenuItemElement action1 =
-                $(AppLayoutElement.class).waitForFirst().getMenuItemWithTitle("Action 1");
+                $(AppLayoutElement.class).waitForFirst().getAppLayoutMenuElement().getMenuItemWithTitle("Action 1");
         action1.click();
         Assert.assertEquals("Action 1 executed!",
-                $(NotificationElement.class).waitForFirst().getText().trim());
+                 $(NotificationElement.class).waitForFirst().getText().trim());
 
         MenuItemElement action2 =
-                $(AppLayoutElement.class).waitForFirst().getMenuItemWithTitle("Action 2");
+                $(AppLayoutElement.class).waitForFirst().getAppLayoutMenuElement().getMenuItemWithTitle("Action 2");
         action2.click();
         Assert.assertEquals("Action 2 executed!",
                 $(NotificationElement.class).last().getText().trim());
@@ -73,13 +76,13 @@ public class AppLayoutIT extends AbstractParallelTest {
     @Test
     public void actionMenuItems_doNotUpdateSelectedMenuItem() {
         String initialSelectionTitle = $(AppLayoutElement.class)
-                .waitForFirst().getSelectedMenuItem().getTitle();
+                .waitForFirst().getAppLayoutMenuElement().getSelectedMenuItem().getTitle();
 
-        $(AppLayoutElement.class).waitForFirst()
+        $(AppLayoutElement.class).waitForFirst().getAppLayoutMenuElement()
                 .getMenuItemWithTitle("Action 1").click();
 
         String selectionTitleAfterActionClick = $(AppLayoutElement.class)
-                .waitForFirst().getSelectedMenuItem().getTitle();
+                .waitForFirst().getAppLayoutMenuElement().getSelectedMenuItem().getTitle();
 
         Assert.assertEquals(initialSelectionTitle, selectionTitleAfterActionClick);
     }
@@ -87,17 +90,17 @@ public class AppLayoutIT extends AbstractParallelTest {
     @Test
     public void routingMenuItems() {
         String initialSelectionTitle = $(AppLayoutElement.class)
-                .waitForFirst().getSelectedMenuItem().getTitle();
+                .waitForFirst().getAppLayoutMenuElement().getSelectedMenuItem().getTitle();
 
         Assert.assertEquals("Home", initialSelectionTitle);
         Assert.assertEquals("Welcome home",
                 $(AppLayoutElement.class).waitForFirst().getContent().getText());
 
-        $(AppLayoutElement.class).waitForFirst()
+        $(AppLayoutElement.class).waitForFirst().getAppLayoutMenuElement()
                 .getMenuItemWithTitle("Page 2").click();
 
         String selectionTitleAfterActionClick = $(AppLayoutElement.class)
-                .waitForFirst().getSelectedMenuItem().getTitle();
+                .waitForFirst().getAppLayoutMenuElement().getSelectedMenuItem().getTitle();
 
         Assert.assertEquals("Page 2", selectionTitleAfterActionClick);
         Assert.assertEquals("This is Page 2",
@@ -112,7 +115,21 @@ public class AppLayoutIT extends AbstractParallelTest {
         Assert.assertTrue($(AppLayoutElement.class).waitForFirst().getContent()
                 .getText().contains("Could not navigate to"));
 
-        Assert.assertFalse($(AppLayoutElement.class).first().getMenu().$(MenuItemElement.class)
+        Assert.assertFalse($(AppLayoutElement.class).first().getAppLayoutMenuElement().$(MenuItemElement.class)
                 .attribute("selected", "").exists());
+    }
+
+    @Test
+    public void menuWithRoutingLinksWorks() {
+        getDriver().get(getBaseURL() + "/Page3");
+        Assert.assertEquals("This is Page 3",
+            $(AppLayoutElement.class).waitForFirst().getContent().getText());
+
+        TestBenchElement linkPage4 = $(AppLayoutElement.class).waitForFirst().getMenu(TestBenchElement.class).$("a").get(1);
+        Assert.assertEquals("Page 4",linkPage4.getText());
+        linkPage4.click();
+        Assert.assertEquals("This is Page 4",
+            $(AppLayoutElement.class).waitForFirst().getContent().getText());
+
     }
 }

--- a/vaadin-app-layout-testbench/src/main/java/com/vaadin/flow/component/applayout/testbench/AppLayoutElement.java
+++ b/vaadin-app-layout-testbench/src/main/java/com/vaadin/flow/component/applayout/testbench/AppLayoutElement.java
@@ -36,27 +36,12 @@ public class AppLayoutElement extends TestBenchElement {
                 contentPlaceholder);
     }
 
-    public TestBenchElement getMenu() {
-        return $(TestBenchElement.class).attribute("slot", "menu").first();
+    public <T extends TestBenchElement> T getMenu(Class<T> clazz) {
+        return $(clazz).attribute("slot", "menu").waitForFirst();
     }
 
-    public List<MenuItemElement> getMenuItems() {
-        return getMenu().$(MenuItemElement.class).all();
+    public AppLayoutMenuElement getAppLayoutMenuElement() {
+        return getMenu(AppLayoutMenuElement.class);
     }
 
-    public MenuItemElement getMenuItemAt(int index) {
-        return getMenu().$(MenuItemElement.class).get(index);
-    }
-
-    public MenuItemElement getMenuItemWithTitle(String title) {
-        return getMenu().$(MenuItemElement.class).attribute("title", title).first();
-    }
-
-    public MenuItemElement getSelectedMenuItem() {
-        return getMenu().$(MenuItemElement.class).attribute("selected", "").first();
-    }
-
-    public int countMenuItems() {
-        return getMenuItems().size();
-    }
 }

--- a/vaadin-app-layout-testbench/src/main/java/com/vaadin/flow/component/applayout/testbench/AppLayoutMenuElement.java
+++ b/vaadin-app-layout-testbench/src/main/java/com/vaadin/flow/component/applayout/testbench/AppLayoutMenuElement.java
@@ -1,0 +1,46 @@
+package com.vaadin.flow.component.applayout.testbench;
+
+/*
+ * #%L
+ * Vaadin App Layout Testbench API
+ * %%
+ * Copyright (C) 2018 Vaadin Ltd
+ * %%
+ * This program is available under Commercial Vaadin Add-On License 3.0
+ * (CVALv3).
+ * 
+ * See the file license.html distributed with this software for more
+ * information about licensing.
+ * 
+ * You should have received a copy of the CVALv3 along with this program.
+ * If not, see <http://vaadin.com/license/cval-3>.
+ * #L%
+ */
+
+import com.vaadin.flow.component.tabs.testbench.TabsElement;
+
+import java.util.List;
+
+public class AppLayoutMenuElement extends TabsElement {
+
+    public List<MenuItemElement> getMenuItems() {
+        return this.$(MenuItemElement.class).all();
+    }
+
+    public MenuItemElement getMenuItemAt(int index) {
+        return this.$(MenuItemElement.class).get(index);
+    }
+
+    public MenuItemElement getMenuItemWithTitle(String title) {
+        return this.$(MenuItemElement.class).attribute("title", title).first();
+    }
+
+    public MenuItemElement getSelectedMenuItem() {
+        return this.$(MenuItemElement.class).attribute("selected", "").first();
+    }
+
+    public int countMenuItems() {
+        return getMenuItems().size();
+    }
+
+}

--- a/vaadin-app-layout-testbench/src/main/java/com/vaadin/flow/component/applayout/testbench/MenuItemElement.java
+++ b/vaadin-app-layout-testbench/src/main/java/com/vaadin/flow/component/applayout/testbench/MenuItemElement.java
@@ -1,5 +1,22 @@
 package com.vaadin.flow.component.applayout.testbench;
 
+/*
+ * #%L
+ * Vaadin App Layout Testbench API
+ * %%
+ * Copyright (C) 2018 Vaadin Ltd
+ * %%
+ * This program is available under Commercial Vaadin Add-On License 3.0
+ * (CVALv3).
+ * 
+ * See the file license.html distributed with this software for more
+ * information about licensing.
+ * 
+ * You should have received a copy of the CVALv3 along with this program.
+ * If not, see <http://vaadin.com/license/cval-3>.
+ * #L%
+ */
+
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
 


### PR DESCRIPTION
- Created test for menu using RouterLinks instead of the default menu
- Refactored TestBench elements to reflect creation of `AppLayoutMenu` class and to allow testing with other types of menus

Closes #11

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-app-layout-flow/44)
<!-- Reviewable:end -->
