### PR TITLE
Limit TestsInParallel parameter

### DIFF
--- a/vaadin-app-layout-integration-tests/pom.xml
+++ b/vaadin-app-layout-integration-tests/pom.xml
@@ -268,6 +268,7 @@
                                 <sauce.user>${sauce.user}</sauce.user>
                                 <sauce.sauceAccessKey>${sauce.sauceAccessKey}</sauce.sauceAccessKey>
                                 <sauce.options>${sauce.options}</sauce.options>
+                                <com.vaadin.testbench.Parameters.testsInParallel>5</com.vaadin.testbench.Parameters.testsInParallel>
                             </systemPropertyVariables>
                             <trimStackTrace>false</trimStackTrace>
                         </configuration>


### PR DESCRIPTION
The default unlimited count can potentially hang the system when running tests locally

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-app-layout-flow/60)
<!-- Reviewable:end -->
