### PR TITLE
Remove license entry

### DIFF
--- a/vaadin-app-layout-flow/pom.xml
+++ b/vaadin-app-layout-flow/pom.xml
@@ -12,14 +12,6 @@
     <packaging>jar</packaging>
     <name>Vaadin App Layout</name>
 
-    <licenses>
-        <license>
-            <name>Apache License Version 2.0</name>
-            <distribution>repo</distribution>
-            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-        </license>
-    </licenses>
-
     <properties>
         <powermock.version>1.7.1</powermock.version>
     </properties>

--- a/vaadin-app-layout-testbench/pom.xml
+++ b/vaadin-app-layout-testbench/pom.xml
@@ -10,14 +10,6 @@
     </parent>
     <artifactId>vaadin-app-layout-testbench</artifactId>
 
-   <licenses>
-        <license>
-            <name>Apache License Version 2.0</name>
-            <distribution>repo</distribution>
-            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-        </license>
-    </licenses>
-
     <packaging>jar</packaging>
     <name>Vaadin App Layout Testbench API</name>
     <dependencies>


### PR DESCRIPTION
**Apache 2.0** is coming from `vaadin-parent` > `flow-component-base`