### PR TITLE
Align use of dependencies with other components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jetty.plugin.version>9.4.11.v20180605</jetty.plugin.version>
+        <button.version>2.0.1</button.version>
     </properties>
 
     <modules>

--- a/vaadin-app-layout-flow/pom.xml
+++ b/vaadin-app-layout-flow/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-button-flow</artifactId>
-            <version>2.0.0</version>
+            <version>${button.version}</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
@@ -81,11 +81,6 @@
             <version>2.1.1</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.webjars.bowergithub.vaadin</groupId>
-            <artifactId>vaadin-button</artifactId>
-            <version>2.2.0</version>
-        </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-control-state-mixin</artifactId>


### PR DESCRIPTION
- Use property for setting the version of vaadin-button.
- Depend on the webjar coming from vaadin-button-flow instead of pinning directly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-app-layout-flow/120)
<!-- Reviewable:end -->
