### PR TITLE
Fix DrawerToggle setIcon by not setting the slot name attribute

### DIFF
--- a/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/DrawerToggle.java
+++ b/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/DrawerToggle.java
@@ -20,6 +20,7 @@ package com.vaadin.flow.component.applayout;
  * #L%
  */
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dependency.HtmlImport;
@@ -40,4 +41,12 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 @NpmPackage(value = "@vaadin/vaadin-app-layout", version = "2.0.3")
 @JsModule("@vaadin/vaadin-app-layout/src/vaadin-drawer-toggle.js")
 public class DrawerToggle extends Button {
+
+    public void setIcon(Component icon) {
+        super.setIcon(icon);
+        // the slot attribute needs to be removed because vaadin-drawer-toggle
+        // template doesn't have prefix and suffix slots
+        icon.getElement().removeAttribute("slot");
+    }
+
 }

--- a/vaadin-app-layout-integration-tests/src/main/java/com/vaadin/flow/component/applayout/examples/AppRouterLayout.java
+++ b/vaadin-app-layout-integration-tests/src/main/java/com/vaadin/flow/component/applayout/examples/AppRouterLayout.java
@@ -2,6 +2,8 @@ package com.vaadin.flow.component.applayout.examples;
 
 import com.vaadin.flow.component.applayout.AppLayout;
 import com.vaadin.flow.component.applayout.DrawerToggle;
+import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.page.BodySize;
 import com.vaadin.flow.router.RouterLink;
@@ -12,13 +14,21 @@ import com.vaadin.flow.theme.lumo.Lumo;
 @Theme(Lumo.class)
 public class AppRouterLayout extends AppLayout {
 
-    {
-        final DrawerToggle drawerToggle = new DrawerToggle();
-        final RouterLink home = new RouterLink("Home", Home.class);
-        final RouterLink page1 = new RouterLink("Page 1", Page1.class);
-        final RouterLink page2 = new RouterLink("Page 2", Page2.class);
-        final VerticalLayout layout = new VerticalLayout(home, page1, page2);
+    public static final String CUSTOM_TOGGLE_ID = "toggle-with-icon";
+    public static final String CUSTOM_ICON_ID = "custom-icon";
+
+    public AppRouterLayout() {
+        RouterLink home = new RouterLink("Home", Home.class);
+        RouterLink page1 = new RouterLink("Page 1", Page1.class);
+        RouterLink page2 = new RouterLink("Page 2", Page2.class);
+        VerticalLayout layout = new VerticalLayout(home, page1, page2);
         addToDrawer(layout);
-        addToNavbar(drawerToggle);
+        addToNavbar(new DrawerToggle());
+        DrawerToggle customToggle = new DrawerToggle();
+        customToggle.setId(CUSTOM_TOGGLE_ID);
+        Icon icon = VaadinIcon.FLIP_H.create();
+        icon.setId(CUSTOM_ICON_ID);
+        customToggle.setIcon(icon);
+        addToNavbar(customToggle);
     }
 }

--- a/vaadin-app-layout-integration-tests/src/test/java/com/vaadin/flow/component/applayout/test/AppLayoutIT.java
+++ b/vaadin-app-layout-integration-tests/src/test/java/com/vaadin/flow/component/applayout/test/AppLayoutIT.java
@@ -1,10 +1,15 @@
 package com.vaadin.flow.component.applayout.test;
 
+import static com.vaadin.flow.component.applayout.examples.AppRouterLayout.CUSTOM_ICON_ID;
+import static com.vaadin.flow.component.applayout.examples.AppRouterLayout.CUSTOM_TOGGLE_ID;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.applayout.testbench.AppLayoutElement;
+import com.vaadin.flow.component.applayout.testbench.DrawerToggleElement;
+import com.vaadin.testbench.TestBenchElement;
 
 public class AppLayoutIT extends AbstractParallelTest {
 
@@ -49,5 +54,20 @@ public class AppLayoutIT extends AbstractParallelTest {
             $(AppLayoutElement.class).waitForFirst().getContent()
                 .getText().contains("Could not navigate to"));
 
+    }
+
+    @Test
+    public void customIcon() {
+        AppLayoutElement layout = $(AppLayoutElement.class).waitForFirst();
+        Assert.assertEquals(2,
+                layout.$(DrawerToggleElement.class).all().size());
+
+        DrawerToggleElement customToggle = layout.$(DrawerToggleElement.class)
+                .id(CUSTOM_TOGGLE_ID);
+        Assert.assertTrue(customToggle.isDisplayed());
+
+        TestBenchElement iconElement = customToggle.$("iron-icon")
+                .id(CUSTOM_ICON_ID);
+        Assert.assertTrue(iconElement.isDisplayed());
     }
 }


### PR DESCRIPTION
Currently DrawerToggle extends Button but it shouldn't because
the toggle template is not the compatible with vaadin-button template
making inherited behavior from Button not work

The proper fix for this requires not extending Button and is a breaking change

Overriding setIcon allows fixing this in a maintenance release

Fixes #117

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-app-layout-flow/121)
<!-- Reviewable:end -->
