### PR TITLE
fix: don't use PropertyDescriptor for drawerOpened

### DIFF
--- a/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
+++ b/vaadin-app-layout-flow/src/main/java/com/vaadin/flow/component/applayout/AppLayout.java
@@ -42,8 +42,6 @@ import java.util.Objects;
 public class AppLayout extends Component implements RouterLayout {
     private static final PropertyDescriptor<String, String> primarySectionProperty = PropertyDescriptors
         .propertyWithDefault("primarySection", Section.NAVBAR.toWebcomponentValue());
-    private static final PropertyDescriptor<Boolean, Boolean> drawerOpenedProperty = PropertyDescriptors
-        .propertyWithDefault("drawerOpened", true);
     private static final PropertyDescriptor<Boolean, Boolean> overlayProperty = PropertyDescriptors
         .propertyWithDefault("overlay", false);
 
@@ -86,7 +84,7 @@ public class AppLayout extends Component implements RouterLayout {
      */
     @Synchronize("drawer-opened-changed")
     public boolean isDrawerOpened() {
-        return drawerOpenedProperty.get(this);
+        return getElement().getProperty("drawerOpened", true);
     }
 
     /**
@@ -97,7 +95,7 @@ public class AppLayout extends Component implements RouterLayout {
      * @see DrawerToggle for a component that allows the user to open and close the drawer.
      */
     public void setDrawerOpened(boolean drawerOpened) {
-        drawerOpenedProperty.set(this, drawerOpened);
+        getElement().setProperty("drawerOpened", drawerOpened);
     }
 
     /**

--- a/vaadin-app-layout-flow/src/test/java/com/vaadin/flow/component/applayout/AppLayoutTest.java
+++ b/vaadin-app-layout-flow/src/test/java/com/vaadin/flow/component/applayout/AppLayoutTest.java
@@ -158,6 +158,23 @@ public class AppLayoutTest {
         testAfterNavigationClosesDrawerOnOverlay(expectedDrawerOpened);
     }
 
+    @Test
+    public void testDrawerOpen() {
+        systemUnderTest.setDrawerOpened(true);
+        testDrawerOpened(true);
+    }
+
+    @Test
+    public void testDrawerClose() {
+        systemUnderTest.setDrawerOpened(false);
+        testDrawerOpened(false);
+    }
+
+    private void testDrawerOpened(boolean expectedDrawerOpened) {
+        assertEquals(expectedDrawerOpened, systemUnderTest.getElement().getProperty("drawerOpened", false));
+        assertEquals(expectedDrawerOpened, systemUnderTest.isDrawerOpened());
+    }
+
     private void testAfterNavigationClosesDrawerOnOverlay(
         boolean expectedDrawerOpened) {
         systemUnderTest.setDrawerOpened(true);


### PR DESCRIPTION
Fixes #136 

`PropertyDescriptors.propertyWithDefault` doesn't play well with properties that have `true` as the default value.
When PropertyDescriptor is assigned the default value, it actually clears the element property instead of setting the default as its value (!!!).

In the case of `drawerOpened`, whenever the value is set to `true`, it being the default value, the `element.drawerOpened` value actually gets set to `null`. And since `null` is a falsy value, the AppLayout Web Component (rightfully) closes the drawer.

This PR makes the `drawerOpened` APIs use direct element property getter/setter instead.